### PR TITLE
Make it easier to debug missing program during build.

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -9,7 +9,6 @@ import Distribution.Types.LocalBuildInfo
 import System.Directory
 import System.FilePath
 
-import Debug.Trace(trace)
 
 main :: IO ()
 main =
@@ -22,9 +21,9 @@ main =
           let verbosity = fromFlag (configVerbosity (configFlags lbi))
               binaryen_builddir = binaryenBuildDir lbi
               run prog args =
-                let conf_prog = case lookupProgram prog (withPrograms lbi)
-                                  Just conf_prog -> conf_prog
-                                  Nothing -> error $ "Cannot find the build program "
+                let conf_prog = case lookupProgram prog (withPrograms lbi) of
+                                  Just theProg -> theProg
+                                  Nothing -> error $ "Cannot find the "
                                                   <>  show prog
                  in runProgramInvocation
                       verbosity

--- a/Setup.hs
+++ b/Setup.hs
@@ -9,6 +9,8 @@ import Distribution.Types.LocalBuildInfo
 import System.Directory
 import System.FilePath
 
+import Debug.Trace(trace)
+
 main :: IO ()
 main =
   defaultMainWithHooks
@@ -20,7 +22,10 @@ main =
           let verbosity = fromFlag (configVerbosity (configFlags lbi))
               binaryen_builddir = binaryenBuildDir lbi
               run prog args =
-                let Just conf_prog = lookupProgram prog (withPrograms lbi)
+                let conf_prog = case lookupProgram prog (withPrograms lbi)
+                                  Just conf_prog -> conf_prog
+                                  Nothing -> error $ "Cannot find the build program "
+                                                  <>  show prog
                  in runProgramInvocation
                       verbosity
                       (programInvocation conf_prog args)


### PR DESCRIPTION
When building without `cmake` present, we get this error message:
```
binaryen> configure   
binaryen> [1 of 2] Compiling Main             ( /tmp/stack5789/binaryen-0.0.1/Setup.hs, /tmp/stack5789/binaryen-0.0.1/.stack-work/dist/x86_64-linux-custom-asterius-tinfo6/Cabal-2.4.0.1/setup/Main.o )
binaryen> [2 of 2] Compiling StackSetupShim   ( /home/m/.stack/setup-exe-src/setup-shim-mPHDZzAJ.hs, /tmp/stack5789/binaryen-0.0.1/.stack-work/dist/x86_64-linux-custom-asterius-tinfo6/Cabal-2.4.0.1/setup/StackSetupShim.o )
binaryen> Linking /tmp/stack5789/binaryen-0.0.1/.stack-work/dist/x86_64-linux-custom-asterius-tinfo6/Cabal-2.4.0.1/setup/setup ...
binaryen> Configuring binaryen-0.0.1...
binaryen> build       
binaryen> Preprocessing library for binaryen-0.0.1..
binaryen> Building library for binaryen-0.0.1..
binaryen> [1 of 2] Compiling Bindings.Binaryen.Raw
binaryen> [2 of 2] Compiling Paths_binaryen
binaryen> /tmp/stack5789/binaryen-0.0.1/Setup.hs:23:21-74: Non-exhaustive patterns in Just conf_prog
binaryen>             
                      
--  While building package binaryen-0.0.1 using:
      /tmp/stack5789/binaryen-0.0.1/.stack-work/dist/x86_64-linux-custom-asterius-tinfo6/Cabal-2.4.0.1/setup/setup --builddir=.stack-work/dist/x86_64-linux-custom-asterius-tinfo6/Cabal-2.4.0.1 build --ghc-options " -fdiagnostics-color=always"
    Process exited with code: ExitFailure 1
```
This small patch makes for a better debugging message - it just tells which program is missing.